### PR TITLE
Update zonik_tips_16_vm00_n01.txt

### DIFF
--- a/Update/zonik_tips_16_vm00_n01.txt
+++ b/Update/zonik_tips_16_vm00_n01.txt
@@ -201,7 +201,7 @@ void dialog001()
 	Wait ( 3200 );
 //　早い話が、脳障害によって精神がとんちんかんになる状態じゃな＠これは薬物中毒でも起こるが、脳の外傷や脳炎、脳卒中、脳腫瘍なんかでも起こる。＠
 	OutputLine(NULL, "　早い話が、脳障害によって精神がとんちんかんになる状態じゃな。",
-		   NULL, "In short, it's a condition where the brain is out of whack due to physical injury or illness.", Line_WaitForInput);
+		   NULL, " In short, it's a condition where the brain is out of whack due to physical injury or illness.", Line_WaitForInput);
 	ModPlayVoiceLS(3, 0, "ps3/s20/00/443200037", 128, TRUE);
 	OutputLine(NULL, "これは薬物中毒でも起こるが、脳の外傷や脳炎、脳卒中、脳腫瘍なんかでも起こる。」",
 		   NULL, " It can be caused by drugs, but it can also be caused by physical trauma, encephalitis, a stroke, or even tumors.\"", GetGlobalFlag(GLinemodeSp));


### PR DESCRIPTION
Fixed a tiny spacing issue I noticed while playing through the game. If you look at the screnshot attached, you can see the missing space between the two sentences:

![higurashiep01_2018-12-25_22-56-05](https://user-images.githubusercontent.com/4201229/50497833-6a8b2c80-0a09-11e9-913d-718c686a8d9e.png)
