### PR TITLE
translation consistency fixes

### DIFF
--- a/Update/onik_011.txt
+++ b/Update/onik_011.txt
@@ -3975,7 +3975,7 @@ void main()
 //　妻は雛見沢の奥にある底無し沼に身を投げたらしいのだ＠
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　妻は雛見沢の奥にある底無し沼に身を投げたらしいのだ。",
-		   NULL, "The wife had supposedly thrown herself into the bottomless marsh deep in the forest around Hinamizawa.", GetGlobalFlag(GLinemodeSp));
+		   NULL, "The wife had supposedly thrown herself into the bottomless swamp deep in the forest around Hinamizawa.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n\n", Line_ContinueAfterTyping); }
 
 //　……つまり、状況証拠だけ＠
@@ -3989,7 +3989,7 @@ void main()
 //　遺書と沼の前に揃えられたぞうりだけ…￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　遺書と沼の前に揃えられたぞうりだけ…。",
-		   NULL, "They simply found her suicide note in front of the marsh...", Line_Normal);
+		   NULL, "They simply found her suicide note in front of the swamp...", Line_Normal);
 	ClearMessage();
 
 

--- a/Update/onik_012.txt
+++ b/Update/onik_012.txt
@@ -1346,7 +1346,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(3, 11, "ps3/s01/11/120700226", 256, TRUE);
 	OutputLine(NULL, "「何でもですね、大昔は雛見沢は「鬼ヶ淵」って呼ばれてたんだそうです。」",
-		   NULL, "\"Turns out that Hinamizawa used to be called Onigafuchi—the Demonic Abyss.\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, "\"Turns out that Hinamizawa used to be called Onigafuchi—the Demon's Abyss.\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 

--- a/Update/onik_012.txt
+++ b/Update/onik_012.txt
@@ -1346,7 +1346,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(3, 11, "ps3/s01/11/120700226", 256, TRUE);
 	OutputLine(NULL, "「何でもですね、大昔は雛見沢は「鬼ヶ淵」って呼ばれてたんだそうです。」",
-		   NULL, "\"Turns out that Hinamizawa used to be called Onigafuchi, or Ogres' Abyss.\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, "\"Turns out that Hinamizawa used to be called Onigafuchi—the Demonic Abyss.\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 
@@ -1372,10 +1372,10 @@ void main()
 		   NULL, "\"The name is still around.", Line_WaitForInput);
 	ModPlayVoiceLS(3, 11, "ps3/s01/11/120700228", 256, TRUE);
 	OutputLine(NULL, "…神主の妻が入水自殺した沼の名前は今でも鬼ヶ淵と言うんです。",
-		   NULL, " ...The marsh where the Shinto priest's wife drowned herself is still called Ogres' Abyss.", Line_WaitForInput);
+		   NULL, " ...The swamp where the Shinto priest's wife drowned herself is still called Onigafuchi.", Line_WaitForInput);
 	ModPlayVoiceLS(3, 11, "ps3/s01/11/120700229", 256, TRUE);
 	OutputLine(NULL, "……沼の底の底は鬼たちの住む国とつながってると言われてたんだそうです。」",
-		   NULL, " ...It's said that the depths of that marsh connect to the realm of demons.\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, " ...It's said that the depths of that swamp connect to the realm of demons.\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n\n", Line_ContinueAfterTyping); }
 
 
@@ -1385,7 +1385,7 @@ void main()
 //　もちろん、こんな薄気味悪い沼のことは誰も教えてくれない…￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　もちろん、こんな薄気味悪い沼のことは誰も教えてくれない…。",
-		   NULL, "Of course, nobody had told me anything about such an ominous marsh...", Line_Normal);
+		   NULL, "Of course, nobody had told me anything about such an ominous swamp...", Line_Normal);
 	ClearMessage();
 
 
@@ -1436,7 +1436,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(3, 11, "ps3/s01/11/120700233", 256, TRUE);
 	OutputLine(NULL, "　例えば…不治の病にかかった村人を鬼ヶ淵に運んで、治してもらったりとかしたんだそうです。」",
-		   NULL, "Villagers with incurable illnesses would be taken to the Ogres' Abyss to be healed, for example.\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, "Villagers with incurable illnesses would be taken to Onigafuchi to be healed, for example.\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 
@@ -5459,7 +5459,7 @@ void main()
 //　様々な負の感情はまるで渦巻く底無し沼のように、俺を安らかでない眠りへと引きずりこんで行った………￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　様々な負の感情はまるで渦巻く底無し沼のように、俺を安らかでない眠りへと引きずりこんで行った………。",
-		   NULL, "I fell into a restless sleep as I was crushed by my negative emotions. It was as if I was being drawn into a billowing, bottomless marsh...", Line_Normal);
+		   NULL, "I fell into a restless sleep as I was crushed by my negative emotions. It was as if I was being drawn into a billowing, bottomless swamp...", Line_Normal);
 	ClearMessage();
 
 

--- a/Update/onik_015.txt
+++ b/Update/onik_015.txt
@@ -5714,7 +5714,7 @@ void main()
 //　大昔、雛見沢は鬼が住まう里として恐れられながらも崇められていたという￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　大昔、雛見沢は鬼が住まう里として恐れられながらも崇められていたという。",
-		   NULL, "Long ago, Hinamizawa was feared and respected as the village of ogres.", Line_Normal);
+		   NULL, "Long ago, Hinamizawa was feared and respected as the village of demons.", Line_Normal);
 	ClearMessage();
 	DisableWindow();
 	DrawScene("flashback/oni1", 1000 );
@@ -5723,7 +5723,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(3, 11, "ps3/s01/11/120700495", 256, TRUE);
 	OutputLine(NULL, "「ふもとの村人たちは鬼たちを崇めていました。",
-		   NULL, "\"The villagers at the foot of the mountains worshipped the ogres.", Line_WaitForInput);
+		   NULL, "\"The villagers at the foot of the mountains worshipped the demons.", Line_WaitForInput);
 	ModPlayVoiceLS(3, 11, "ps3/s01/11/120700496", 256, TRUE);
 	OutputLine(NULL, "で、鬼ヶ淵は神聖な土地なので絶対に不可侵。",
 		   NULL, " So Onigafuchi was hallowed ground that you could never enter.", Line_WaitForInput);
@@ -5758,7 +5758,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(3, 11, "ps3/s01/11/120700498", 256, TRUE);
 	OutputLine(NULL, "「鬼たちもまたですね。",
-		   NULL, "\"Also, the ogres, you see...", Line_WaitForInput);
+		   NULL, "\"Also, the demons, you see...", Line_WaitForInput);
 	ModPlayVoiceLS(3, 11, "ps3/s01/11/120700499", 256, TRUE);
 	OutputLine(NULL, "俗世に出て行かないよう、オヤシロさまに厳しく見張られていたんだとか。",
 		   NULL, " They were being strictly watched by Oyashiro-sama so they would not enter into our world.", GetGlobalFlag(GLinemodeSp));

--- a/Update/onik_tips_05.txt
+++ b/Update/onik_tips_05.txt
@@ -83,9 +83,9 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n\n", Line_ContinueAfterTyping); }
 
 
-//　水没地域はもとより全部落は郷土死守の決意を固め次々に決起、団結し鬼ケ淵死守同盟を結成＠
+//　水没地域はもとより全部落は郷土死守の決意を固め次々に決起、団結し鬼ヶ淵死守同盟を結成＠
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
-	OutputLine(NULL, "　水没地域はもとより全部落は郷土死守の決意を固め次々に決起、団結し鬼ケ淵死守同盟を結成。",
+	OutputLine(NULL, "　水没地域はもとより全部落は郷土死守の決意を固め次々に決起、団結し鬼ヶ淵死守同盟を結成。",
 		   NULL, "All the residents having homes that were to be submerged banded together, and created the Onigafuchi Defense Alliance.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n\n", Line_ContinueAfterTyping); }
 
@@ -133,9 +133,9 @@ void main()
 		   NULL, " and they understand that this fearsome plan has not yet been fully withdrawn.", Line_Normal);
 	ClearMessage();
 
-//　すでに鬼ケ淵死守同盟はその役割を終え解散しているが、そこで育まれた団結の炎は消えていない＠
+//　すでに鬼ヶ淵死守同盟はその役割を終え解散しているが、そこで育まれた団結の炎は消えていない＠
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
-	OutputLine(NULL, "　すでに鬼ケ淵死守同盟はその役割を終え解散しているが、そこで育まれた団結の炎は消えていない。",
+	OutputLine(NULL, "　すでに鬼ヶ淵死守同盟はその役割を終え解散しているが、そこで育まれた団結の炎は消えていない。",
 		   NULL, "The Onigafuchi Defense Alliance had been dissolved after it did its part, but the feelings of unity it garnered have not yet been extinguished.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
@@ -148,10 +148,10 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n\n\n", Line_ContinueAfterTyping); }
 
 
-//　　　　　鬼ケ淵死守同盟会長!w1000　公由喜一郎￥
+//　　　　　鬼ヶ淵死守同盟会長!w1000　公由喜一郎￥
 
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
-	OutputLine(NULL, "　　　　　鬼ケ淵死守同盟会長",
+	OutputLine(NULL, "　　　　　鬼ヶ淵死守同盟会長",
 		   NULL, "Onigafuchi Defense Alliance Committee Chairman,", Line_ContinueAfterTyping);
 
 	SetValidityOfInput( FALSE );

--- a/Update/onik_tips_06.txt
+++ b/Update/onik_tips_06.txt
@@ -242,9 +242,9 @@ void main()
 //「ＸＸが死体（右腕）を沼に捨てに行くと言っていたらしいのです＠実際、沼の近くにＸＸの乗用車が乗り捨ててあったのですが、その後の足取りはまったくわかりません。＠
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "「ＸＸが死体（右腕）を沼に捨てに行くと言っていたらしいのです。",
-		   NULL, "\"It appears that XX had said he was going to throw the body (right arm) into the marsh.", Line_WaitForInput);
+		   NULL, "\"It appears that XX had said he was going to throw the body (right arm) into the swamp.", Line_WaitForInput);
 	OutputLine(NULL, "実際、沼の近くにＸＸの乗用車が乗り捨ててあったのですが、その後の足取りはまったくわかりません。」",
-		   NULL, " XX's car was discovered abandoned near the marsh, but there were no clues to his whereabouts.\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, " XX's car was discovered abandoned near the swamp, but there were no clues to his whereabouts.\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n\n", Line_ContinueAfterTyping); }
 
 
@@ -270,15 +270,15 @@ void main()
 		   NULL, " Since he has no car, one would expect him to have a limited area to which he could have escaped to. ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "署内では、死体を捨てる時に誤って自分も沼に溺れてしまったのではないかと囁かれています…。」",
-		   NULL, "But within the station there were rumors going around that he had accidentally slipped and drowned in the marsh when he went to throw away the body.\"", Line_Normal);
+		   NULL, "But within the station there were rumors going around that he had accidentally slipped and drowned in the swamp when he went to throw away the body.\"", Line_Normal);
 	ClearMessage();
 
 //　この沼、地元では底なし沼と恐れられ＠その名を鬼ヶ淵と言い、沼の底の底は地獄の鬼の国につながっているのだという＠
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　この沼、地元では底なし沼と恐れられ、",
-		   NULL, "To the locals, that marsh is believed to be bottomless.", Line_WaitForInput);
+		   NULL, "To the locals, that swamp is believed to be bottomless.", Line_WaitForInput);
 	OutputLine(NULL, "その名を鬼ヶ淵と言い、沼の底の底は地獄の鬼の国につながっているのだという。",
-		   NULL, " It's known as Onigafuchi, the Ogre's Abyss, and it's said that the bottom of the marsh is connected to the hellish world of demons.", GetGlobalFlag(GLinemodeSp));
+		   NULL, " It's known as Onigafuchi, the Demonic Abyss, and it's said that the bottom of the swamp is connected to the hellish world of demons.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 
@@ -288,7 +288,7 @@ void main()
 	OutputLine(NULL, "　まさに地獄の鬼とも言える残虐非道のＸＸ。",
 		   NULL, "The atrocious demon from hell that was XX.", Line_WaitForInput);
 	OutputLine(NULL, "まさか沼から元の地獄へ帰ったのでは…？",
-		   NULL, " Could it be that he had returned to hell through the marsh...?", Line_Normal);
+		   NULL, " Could it be that he had returned to hell through the swamp...?", Line_Normal);
 	ClearMessage();
 
 	PlaySE( 4, "wa_029", 56, 64 );

--- a/Update/onik_tips_06.txt
+++ b/Update/onik_tips_06.txt
@@ -278,7 +278,7 @@ void main()
 	OutputLine(NULL, "　この沼、地元では底なし沼と恐れられ、",
 		   NULL, "To the locals, that swamp is believed to be bottomless.", Line_WaitForInput);
 	OutputLine(NULL, "その名を鬼ヶ淵と言い、沼の底の底は地獄の鬼の国につながっているのだという。",
-		   NULL, " It's known as Onigafuchi, the Demonic Abyss, and it's said that the bottom of the swamp is connected to the hellish world of demons.", GetGlobalFlag(GLinemodeSp));
+		   NULL, " It's known as Onigafuchi, the Demon's Abyss, and it's said that the bottom of the swamp is connected to the hellish world of demons.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 

--- a/Update/onik_tips_10.txt
+++ b/Update/onik_tips_10.txt
@@ -49,7 +49,7 @@ void main()
 //　警察と青年団で捜索を続けているが、遺書で自殺をほのめかした鬼ヶ淵沼は地元では底なし沼として知られており難航している￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　警察と青年団で捜索を続けているが、遺書で自殺をほのめかした鬼ヶ淵沼は地元では底なし沼として知られており難航している。",
-		   NULL, "The police and local youth association continued the search. However, given the presence of the farewell message and the fact that the Onigafuchi marsh is said to be bottomless, they have run into difficulties.", Line_Normal);
+		   NULL, "The police and local youth association continued the search. However, given the presence of the farewell message and the fact that the Onigafuchi swamp is said to be bottomless, they have run into difficulties.", Line_Normal);
 	ClearMessage();
 
 	SetValidityOfInput( FALSE );


### PR DESCRIPTION
marsh -> swamp (沼 can mean either marsh or swamp and there isn't that much of a difference, but it's called a swamp in other translated installments)

ogre -> demon (all other instances of 鬼 are translated as demon and ogre sucks as an approximation of oni anyway)