### PR TITLE
Fix typo

### DIFF
--- a/Update/onik_tips_14.txt
+++ b/Update/onik_tips_14.txt
@@ -245,7 +245,7 @@ void main()
 	OutputLine(NULL, "・人間関係を徹底的に調べる！",
 		   NULL, "・Need to thoroughly investigate their relationship!", Line_WaitForInput);
 	OutputLine(NULL, "　＞　勤務先他",
-		   NULL, " >Place of work, etc.", GetGlobalFlag(GLinemodeSp));
+		   NULL, " > Place of work, etc.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 


### PR DESCRIPTION
Typo I've found while playing the game, it's just a missing space.
On the screenshot, it's at the end of 3rd line, after the `>` char.

<img width="3360" height="2100" alt="image" src="https://github.com/user-attachments/assets/fc7fbf4f-74cb-4191-80a2-ef1d1dfa7120" />